### PR TITLE
test cases added for iphone crash emoji

### DIFF
--- a/test/runes.js
+++ b/test/runes.js
@@ -128,3 +128,11 @@ test('✂️  substring', (t) => {
   t.deepEqual(substring('👨‍👨‍👧‍👧abc', 1), 'abc')
   t.deepEqual(substring('👨‍👨‍👧‍👧abcd', 2), 'bcd')
 })
+
+test('✂️  Runes should handle ⚐0🌈', (t) => {
+  t.deepEqual(runes('⚐0🌈'), ['⚐', '0', '🌈'])
+})
+
+test('✂️  Runes should handle 🇹🇼', (t) => {
+  t.deepEqual(runes('🇹🇼'), ['🇹🇼'])
+})


### PR DESCRIPTION
**Taiwan flag not render**
https://www.theverge.com/2019/10/7/20903613/apple-hiding-taiwan-flag-emoji-hong-kong-macau-china

**Iphone crash due to this emoji** 
https://www.youtube.com/watch?v=G0iPhSuiMpk&t=9s